### PR TITLE
Improve splat compatibility

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod libultra;
 mod splat;
 mod symbols;
 
-const TAB: &str = "    ";
+const TAB: &str = "      ";
 
 // TODO: do this properly
 const BASE_ADDRESS: u32 = 0x80000400;

--- a/src/main.rs
+++ b/src/main.rs
@@ -364,9 +364,22 @@ fn run(config: &Config) -> Result<(), Box<dyn Error>> {
     all_symbols.dedup_by_key(|x| (x.name.clone(), x.address));
 
     for symbol in all_symbols.iter() {
+        if symbol.name == "" {
+            print!("//");
+        }
+        print!(
+            "{} = {:#X}; // ",
+            symbol.name, symbol.address
+        );
+        if symbol.size != 0 {
+            print!(
+                "size:{:#X} ",
+                symbol.size
+            );
+        }
         println!(
-            "{}, {:#X}, {:#X}  ({}, {})",
-            symbol.name, symbol.address, symbol.size, symbol.filename, symbol.defined
+            "({}, {})",
+            symbol.filename, symbol.defined
         );
     }
     // Uncomment this for splat-compatible symbol output until we have proper argument parsing

--- a/src/splat.rs
+++ b/src/splat.rs
@@ -16,16 +16,14 @@ pub fn print_yaml(found_files: &[FoundFile], ambiguous_addresses: &[usize]) {
             "c"
         };
 
-        
         if previous_file_text_end < entry.text_start {
             println!("{}- [{:#X}, asm]", TAB, previous_file_text_end);
         }
-        
-        
+
         if libultra::GENERIC_FILES.contains(&entry.stem.as_str()) {
             comment.push("common form");
         }
-        
+
         if ambiguous_addresses.contains(&entry.text_start) {
             comment.push("ambiguous");
             // ambiguous = true;


### PR DESCRIPTION
Changes output so it can be blindly copied into splat files and it will just work :tm: 

Symbols current output:
```
osTvType, 0x80000300, 0x0  (initialize, false)
osRomBase, 0x80000308, 0x0  (pirawdma, false)
osResetType, 0x8000030C, 0x0  (initialize, false)
osAppNMIBuffer, 0x8000031C, 0x0  (initialize, false)
osSetIntMask, 0x80091110, 0x0  (sched, false)
osCreatePiManager, 0x800911B0, 0x234  (pimgr, true)
ramromMain, 0x800913E4, 0x10C  (pimgr, true)
__osEPiRawStartDma, 0x800914F0, 0x3E0  (epirawdma, true)
, 0x80095354, 0x0  (env, false)
alEnvmixerParam, 0x8009542C, 0x1B4  (env, true)
_pullSubFrame, 0x800955E0, 0x4B8  (env, true)
, 0x800956DE, 0x0  (env, false)
, 0x800957E6, 0x0  (env, false)
```

With this PR:
```
osTvType = 0x80000300; // (initialize, false)
osRomBase = 0x80000308; // (pirawdma, false)
osResetType = 0x8000030C; // (initialize, false)
osAppNMIBuffer = 0x8000031C; // (initialize, false)
osSetIntMask = 0x80091110; // (sched, false)
osCreatePiManager = 0x800911B0; // size:0x234 (pimgr, true)
ramromMain = 0x800913E4; // size:0x10C (pimgr, true)
__osEPiRawStartDma = 0x800914F0; // size:0x3E0 (epirawdma, true)
// = 0x80095354; // (env, false)
alEnvmixerParam = 0x8009542C; // size:0x1B4 (env, true)
_pullSubFrame = 0x800955E0; // size:0x4B8 (env, true)
// = 0x800956DE; // (env, false)
// = 0x800957E6; // (env, false)
```

Symbols with size 0 will now omit outputting a size and symbols with no name will have the line commented out with `//`

Also added a bit of extra space to the outputted `subsegments` list, so it can be easily copied into the yaml file