### PR TITLE
Don't hardcode base address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 object = "0.29.0"
 argh = "0.1.9"
+crc = "3.0.0"

--- a/src/ipl3.rs
+++ b/src/ipl3.rs
@@ -31,7 +31,10 @@ impl CICInfo {
             0xA0DD69F7 => CICInfo::new(0xA0DD69F7, "6106", "7106", 0x200000),
             0x0013579C => CICInfo::new(0x0013579C, "6101", "-", 0x000000),
             0xDAB442CD => CICInfo::new(0xDAB442CD, "-", "7102", 0x80000480),
-            _ => {eprintln!("Unrecognized crc: {:#X}", crc); CICInfo::new(0, "unk", "unk", 0x000000)},
+            _ => {
+                eprintln!("Unrecognized crc: {:#X}", crc);
+                CICInfo::new(0, "unk", "unk", 0x000000)
+            }
         }
     }
 

--- a/src/ipl3.rs
+++ b/src/ipl3.rs
@@ -1,5 +1,4 @@
 use crc;
-use std::io;
 
 // #[derive(Debug, Clone)]
 pub struct CICInfo {
@@ -24,16 +23,16 @@ impl CICInfo {
         }
     }
 
-    pub const fn get_from_crc(crc: u32) -> io::Result<CICInfo> {
-        Ok(match crc {
+    pub fn get_from_crc(crc: u32) -> CICInfo {
+        match crc {
             0xD1F2D592 => CICInfo::new(0xD1F2D592, "6102", "7101", 0x000000),
             0x27DF61E2 => CICInfo::new(0x27DF61E2, "6103", "7103", 0x100000),
             0x229F516C => CICInfo::new(0x229F516C, "6105", "7105", 0x000000),
             0xA0DD69F7 => CICInfo::new(0xA0DD69F7, "6106", "7106", 0x200000),
             0x0013579C => CICInfo::new(0x0013579C, "6101", "-", 0x000000),
             0xDAB442CD => CICInfo::new(0xDAB442CD, "-", "7102", 0x80000480),
-            _ => CICInfo::new(0, "unk", "unk", 0x000000),
-        })
+            _ => {eprintln!("Unrecognized crc: {:#X}", crc); CICInfo::new(0, "unk", "unk", 0x000000)},
+        }
     }
 
     pub fn name(&self) -> String {
@@ -62,7 +61,7 @@ impl CICInfo {
     }
 }
 
-pub fn identify(reader: &Vec<u8>) -> io::Result<CICInfo> {
+pub fn identify(reader: &Vec<u8>) -> CICInfo {
     let ipl3 = &reader[0x40..0x1000];
 
     const CRC_ALG: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_CKSUM);

--- a/src/ipl3.rs
+++ b/src/ipl3.rs
@@ -1,0 +1,73 @@
+use crc;
+use std::io;
+
+// #[derive(Debug, Clone)]
+pub struct CICInfo {
+    checksum: u32,
+    ntsc_name: &'static str,
+    pal_name: &'static str,
+    entrypoint_offset: u32,
+}
+
+impl CICInfo {
+    const fn new(
+        checksum: u32,
+        ntsc_name: &'static str,
+        pal_name: &'static str,
+        entrypoint_offset: u32,
+    ) -> CICInfo {
+        CICInfo {
+            checksum,
+            ntsc_name,
+            pal_name,
+            entrypoint_offset,
+        }
+    }
+
+    pub const fn get_from_crc(crc: u32) -> io::Result<CICInfo> {
+        Ok(match crc {
+            0xD1F2D592 => CICInfo::new(0xD1F2D592, "6102", "7101", 0x000000),
+            0x27DF61E2 => CICInfo::new(0x27DF61E2, "6103", "7103", 0x100000),
+            0x229F516C => CICInfo::new(0x229F516C, "6105", "7105", 0x000000),
+            0xA0DD69F7 => CICInfo::new(0xA0DD69F7, "6106", "7106", 0x200000),
+            0x0013579C => CICInfo::new(0x0013579C, "6101", "-", 0x000000),
+            0xDAB442CD => CICInfo::new(0xDAB442CD, "-", "7102", 0x80000480),
+            _ => CICInfo::new(0, "unk", "unk", 0x000000),
+        })
+    }
+
+    pub fn name(&self) -> String {
+        if self.ntsc_name == "-" {
+            format!("{}", self.pal_name)
+        } else if self.pal_name == "-" {
+            format!("{}", self.ntsc_name)
+        } else {
+            format!("{} / {}", self.ntsc_name, self.pal_name)
+        }
+        .to_string()
+    }
+
+    const fn entrypoint_offset(&self) -> u32 {
+        self.entrypoint_offset
+    }
+
+    /// Correct the entrypoint: most add a specified number, 7102 hardcodes it.
+    pub const fn correct_entrypoint(&self, header_entrypoint: u32) -> u32 {
+        let offset = self.entrypoint_offset();
+        if offset >= 0x80000000 {
+            offset
+        } else {
+            header_entrypoint - offset
+        }
+    }
+}
+
+pub fn identify(reader: &Vec<u8>) -> io::Result<CICInfo> {
+    let ipl3 = &reader[0x40..0x1000];
+
+    const CRC_ALG: crc::Crc<u32> = crc::Crc::<u32>::new(&crc::CRC_32_CKSUM);
+
+    let hash = CRC_ALG.checksum(&ipl3);
+
+    CICInfo::get_from_crc(hash)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,11 +11,9 @@ mod disambiguate;
 mod libultra;
 mod splat;
 mod symbols;
+mod ipl3;
 
 const TAB: &str = "    ";
-
-// TODO: do this properly
-const BASE_ADDRESS: u32 = 0x80000400;
 
 const FULL_MASK: u32 = 0xFF_FF_FF_FF;
 const ROUGH_MASK: u32 = 0xFC_00_00_00;
@@ -207,13 +205,22 @@ fn run(config: &Config) -> Result<(), Box<dyn Error>> {
     let mut rom_words = Vec::new();
     let start;
     let end;
+    let base_address: u32;
 
     if !config.binary {
         start = 0x1000;
         end = start + 0x100000;
+
+        let cic_info = ipl3::identify(&romfile).unwrap();
+
+        let mut entrypoint_word = Vec::new();
+        words_from_bytes(config, &romfile[0x8..0xC], &mut entrypoint_word);
+
+        base_address = cic_info.correct_entrypoint(entrypoint_word[0]);
     } else {
         start = 0;
         end = romfile.len();
+        base_address = 0x80000400;
     }
 
     let mut files_found = Vec::new(); // length = 1
@@ -281,7 +288,7 @@ fn run(config: &Config) -> Result<(), Box<dyn Error>> {
 
                     // Symbol parsing
                     let mut symbols =
-                        symbols::parse_symtab_functions(&obj_file, &file_stem, BASE_ADDRESS, index)
+                        symbols::parse_symtab_functions(&obj_file, &file_stem, base_address, index)
                             .unwrap();
 
                     symbols.extend(symbols::parse_relocated(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,9 @@ mod ipl3;
 
 const TAB: &str = "    ";
 
+// If no base address is specified, use this common one
+const BASE_ADDRESS: u32 = 0x80000400;
+
 const FULL_MASK: u32 = 0xFF_FF_FF_FF;
 const ROUGH_MASK: u32 = 0xFC_00_00_00;
 const J_TYPE_MASK: u32 = 0xFC_00_00_00;
@@ -235,7 +238,7 @@ fn run(config: &Config) -> Result<(), Box<dyn Error>> {
     } else {
         start = 0;
         end = romfile.len();
-        base_address = config.vram.unwrap();
+        base_address = config.vram.unwrap_or(BASE_ADDRESS);
     }
 
     let mut files_found = Vec::new(); // length = 1

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,7 @@ fn run(config: &Config) -> Result<(), Box<dyn Error>> {
         start = 0x1000;
         end = start + 0x100000;
 
-        let cic_info = ipl3::identify(&romfile).unwrap();
+        let cic_info = ipl3::identify(&romfile);
 
         let mut entrypoint_word = Vec::new();
         words_from_bytes(config, &romfile[0x8..0xC], &mut entrypoint_word);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,6 @@ mod ipl3;
 
 const TAB: &str = "    ";
 
-// If no base address is specified, use this common one
-const BASE_ADDRESS: u32 = 0x80000400;
-
 const FULL_MASK: u32 = 0xFF_FF_FF_FF;
 const ROUGH_MASK: u32 = 0xFC_00_00_00;
 const J_TYPE_MASK: u32 = 0xFC_00_00_00;
@@ -238,7 +235,7 @@ fn run(config: &Config) -> Result<(), Box<dyn Error>> {
     } else {
         start = 0;
         end = romfile.len();
-        base_address = config.vram.unwrap_or(BASE_ADDRESS);
+        base_address = config.vram.expect("Must provide a --vram");
     }
 
     let mut files_found = Vec::new(); // length = 1


### PR DESCRIPTION
I noted flib currently hardcodes the base address to `0x80000400`, which is bad for a lot of n64 games, so I changed it to calculate this address based on the ipl3 of the rom.
The ipl3 calculation stuff is mostly a copy-paste from this https://github.com/EllipticEllipsis/n64rom_analyser/blob/master/src/ipl3.rs